### PR TITLE
fix(LayoutGrid): export GridInner

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export {
   GridTileTitleSupportText
 } from './GridList';
 
-export { Grid, GridCell } from './Grid';
+export { Grid, GridCell, GridInner } from './Grid';
 
 export { Icon } from './Icon';
 


### PR DESCRIPTION
Export GridInner to the global export. It's useful when dealing with multiple nested grids. Of course, for the time being, it is always possible to import: `import { GridInner } from 'rmwc/Grid';` as discussed on another occasion.
Maybe let's also add more info to the documentation? I had to look into the code to make sure what `<Grid/>` is doing.