### PR TITLE
feat(TextField): Add valid prop

### DIFF
--- a/src/TextField/index.js
+++ b/src/TextField/index.js
@@ -108,6 +108,8 @@ type TextFieldPropsT = {
   inputRef?: React.Ref<any>,
   /** Disables the input. */
   disabled?: boolean,
+  /** Sets the Validity state of the input */
+  valid?: boolean,
   /** A label for the input. */
   label?: React.Node,
   /** Add a leading icon. */
@@ -125,6 +127,7 @@ export const TextField = withMDC({
   defaultProps: {
     inputRef: noop,
     disabled: false,
+    valid: undefined,
     box: undefined,
     fullwidth: undefined,
     label: undefined,

--- a/src/TextField/textfield.story.js
+++ b/src/TextField/textfield.story.js
@@ -22,6 +22,7 @@ class TextFieldStory extends React.Component {
         cols={number('cols', 0)}
         textarea={boolean('textarea', false)}
         disabled={boolean('disabled', false)}
+        valid={boolean('valid', true)}
         value={text('value', this.state.value)}
         onChange={evt => this.onChange(evt)}
         label={text('label', 'Hello world')}


### PR DESCRIPTION
Currently there is no possibility to mark a TextField as invalid while mdc provides one.

Please be aware: I'm new to React.JS, thus I guess my PRs are possibly far away from being perfect and may contain errors. If there are better ways to do, please do not hesitate to notice, correct or close.