### PR TITLE
Fixes #73. MDCTabBarScroller creates own instance of MDCTabBar.

### DIFF
--- a/src/Tabs/index.js
+++ b/src/Tabs/index.js
@@ -1,8 +1,7 @@
-// @flow
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { MDCTabBar, MDCTabBarScroller } from '@material/tabs/dist/mdc.tabs';
 import { noop, simpleTag } from '../Base';
-
 import { withMDC } from '../Base';
 import type { SimpleTagPropsT } from '../Base';
 
@@ -30,59 +29,110 @@ type TabBarPropsT = {
   activeTabIndex: number
 } & SimpleTagPropsT;
 
-export const TabBar: React.ComponentType<TabBarPropsT> = withMDC({
+const mdcTabBarEvents = {
+  'MDCTabBar:change': (evt, props, api) => {
+    evt.target.value = api.activeTabIndex;
+    props.onChange(evt);
+  }
+};
+
+export const TabBar_: React.ComponentType<TabBarPropsT> = withMDC({
   mdcConstructor: MDCTabBar,
-  mdcEvents: {
-    'MDCTabBar:change': (evt, props, api) => {
-      evt.target.value = api.activeTabIndex;
-      props.onChange(evt);
-    }
-  },
+  mdcEvents: mdcTabBarEvents,
+
   defaultProps: {
     onChange: noop,
     activeTabIndex: 0
-  },
-  onUpdate: (props, nextProps, api) => {
-    if (!api) {
-      return;
-    }
-    if (!props || nextProps.activeTabIndex !== props.activeTabIndex) {
-      api.activeTabIndex = nextProps.activeTabIndex;
-    }
-  },
-  didUpdate: (props, nextProps, api, inst) => {
-    if (!api) return;
-
-    const childrenDidChange =
-      props &&
-      props.children &&
-      nextProps &&
-      nextProps.children &&
-      JSON.stringify(props.children.map(({ key }) => key)) !==
-      JSON.stringify(nextProps.children.map(({ key }) => key));
-    // destroy the foundation for all tabs manually to remove all  listeners 
-    if (childrenDidChange && api.tabs_) {
-      api.tabs_.forEach(mdcTab => {
-        mdcTab.foundation_ && mdcTab.foundation_.destroy();
-      });
-
-      inst.mdcComponentReinit();
-    }
   }
 })(
   class extends React.Component<TabBarPropsT> {
     static displayName = 'TabBar';
 
+    static contextTypes = {
+      tabBarScrollerPresent: PropTypes.bool
+    };
+
     render() {
       const { children, activeTabIndex, ...rest } = this.props;
       return (
-        <TabBarRoot {...rest}>
+        <TabBarRoot {...rest}
+          className={
+            this.context.tabBarScrollerPresent &&
+            'mdc-tab-bar-scroller__scroll-frame__tabs'
+          } >
           {children}
-          <TabBarIndicatorEl />
-        </TabBarRoot>
+          < TabBarIndicatorEl />
+        </TabBarRoot >
       );
     }
-  });
+  }
+  );
+
+export class TabBar extends TabBar_ {
+  static contextTypes = {
+    tabBarApi: PropTypes.object,
+    tabBarScrollerPresent: PropTypes.bool,
+    tabBarScrollerReinit: PropTypes.func
+  };
+
+  mdcComponentInit() {
+    if (!this.context.tabBarScrollerPresent) {
+      super.mdcComponentInit();
+    }
+  }
+
+  componentWillUpdate(nextProps, nextState, nextContext) {
+    if (nextContext.tabBarScrollerPresent &&
+      nextContext &&
+      nextContext.tabBarApi &&
+      this.mdcApi !== nextContext.tabBarApi) {
+      //  set TabBar API created by TabBarScroller
+      this.mdcApi = nextContext.tabBarApi;
+      //  set activeTabIndex
+      this.mdcApi.activeTabIndex = nextProps.activeTabIndex;
+      // remove old listeners
+      this.mdcUnregisterAllListeners();
+      // Hook event handlers
+      Object.entries(mdcTabBarEvents).forEach(([eventName, handler]) => {
+        this.mdcRegisterListener(eventName, handler);
+      });
+    } else if (this.mdcApi &&
+      (!this.props || this.props.activeTabIndex !== nextProps.activeTabIndex)) {
+      this.mdcApi.activeTabIndex = nextProps.activeTabIndex;
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (!this.mdcApi) return;
+    // check if tabs have changed
+    const childrenDidChange =
+      prevProps &&
+      prevProps.children &&
+      this.props &&
+      this.props.children &&
+      JSON.stringify(prevProps.children.map(({ key }) => key)) !==
+      JSON.stringify(this.props.children.map(({ key }) => key));
+
+    if (childrenDidChange && this.mdcApi.tabs_) {
+      // destroy the foundation for all tabs 
+      // manually to remove all  listeners 
+      this.mdcApi.tabs_.forEach(mdcTab => {
+        mdcTab.foundation_ && mdcTab.foundation_.destroy();
+      });
+      // when tab scroller is wrapping the component
+      if (this.context.tabBarScrollerPresent) {
+        // destroy the foundation
+        this.mdcComponentDestroy();
+        // trigger reinit on the scroller container
+        this.context.tabBarScrollerReinit();
+      } else {
+        // reinit
+        this.mdcComponentReinit();
+      }
+    }
+  }
+}
+
 
 export const TabBarScrollerRoot = simpleTag({
   displayName: 'TabBarScrollerRoot',
@@ -90,16 +140,16 @@ export const TabBarScrollerRoot = simpleTag({
   classNames: 'mdc-tab-bar-scroller'
 });
 
-export const TabBarScrollerIndicatorBackEl = simpleTag({
-  displayName: 'TabBarScrollerIndicatorBackEl',
+export const TabBarScrollerIndicatorBack = simpleTag({
+  displayName: 'TabBarScrollerIndicatorBack',
   tag: 'div',
   classNames: [
     'mdc-tab-bar-scroller__indicator',
     'mdc-tab-bar-scroller__indicator--back'
   ]
 });
-export const TabBarScrollerIndicatorForwardEl = simpleTag({
-  displayName: 'TabBarScrollerIndicatorForwardEl',
+export const TabBarScrollerIndicatorForward = simpleTag({
+  displayName: 'TabBarScrollerIndicatorForward',
   tag: 'div',
   classNames: [
     'mdc-tab-bar-scroller__indicator',
@@ -107,51 +157,73 @@ export const TabBarScrollerIndicatorForwardEl = simpleTag({
   ]
 });
 
-export const TabBarScrollerIndicatorInnerEl = simpleTag({
-  displayName: 'TabBarScrollerIndicatorInnerEl',
+export const TabBarScrollerIndicatorInner = simpleTag({
+  displayName: 'TabBarScrollerIndicatorInner',
   tag: 'a',
   classNames: ['mdc-tab-bar-scroller__indicator__inner', 'material-icons']
 });
 
-export const TabBarScrollerScrollFrameEl = simpleTag({
+export const TabBarScrollerScrollFrame = simpleTag({
   displayName: 'TabBarScrollerScrollFrameEl',
   tag: 'div',
   classNames: 'mdc-tab-bar-scroller__scroll-frame'
 });
 
-export const TabBarScroller: React.ComponentType = withMDC({
-  mdcConstructor: function(el) {
-    if (el) {
-      const tabBarEl = el.querySelector('.mdc-tab-bar');
-      if (tabBarEl) {
-        tabBarEl.classList.add('mdc-tab-bar-scroller__scroll-frame__tabs');
-      }
-    }
-    return new MDCTabBarScroller(el);
-  }
+const TabBarScroller_: React.ComponentType = withMDC({
+  mdcConstructor: MDCTabBarScroller
 })(
   class extends React.Component {
-    static displayName = 'TabBarScroller';
-
     render() {
       const { children, ...rest } = this.props;
+
       return (
         <TabBarScrollerRoot {...rest}>
-          <TabBarScrollerIndicatorBackEl>
-            <TabBarScrollerIndicatorInnerEl>
+          <TabBarScrollerIndicatorBack>
+            <TabBarScrollerIndicatorInner>
               navigate_before
-            </TabBarScrollerIndicatorInnerEl>
-          </TabBarScrollerIndicatorBackEl>
-          <TabBarScrollerScrollFrameEl>{children}</TabBarScrollerScrollFrameEl>
-          <TabBarScrollerIndicatorForwardEl>
-            <TabBarScrollerIndicatorInnerEl>
+            </TabBarScrollerIndicatorInner>
+          </TabBarScrollerIndicatorBack>
+          <TabBarScrollerScrollFrame>{children}</TabBarScrollerScrollFrame>
+          <TabBarScrollerIndicatorForward>
+            <TabBarScrollerIndicatorInner>
               navigate_next
-            </TabBarScrollerIndicatorInnerEl>
-          </TabBarScrollerIndicatorForwardEl>
+            </TabBarScrollerIndicatorInner>
+          </TabBarScrollerIndicatorForward>
         </TabBarScrollerRoot>
       );
     }
-  }
-);
+  });
 
+export class TabBarScroller extends TabBarScroller_ {
+  static displayName = 'TabBarScroller';
+
+  static childContextTypes = {
+    tabBarScrollerReinit: PropTypes.func,
+    tabBarApi: PropTypes.object,
+    tabBarScrollerPresent: PropTypes.bool
+  }
+
+  constructor(props) {
+    super(props);
+    this.reinitTabScroller = this.reinitTabScroller.bind(this);
+  }
+
+  reinitTabScroller() {
+    super.mdcComponentReinit();
+    this.forceUpdate();
+  }
+
+  getChildContext() {
+    return {
+      tabBarScrollerReinit: this.reinitTabScroller,
+      tabBarApi: this.mdcApi && this.mdcApi.tabBar_,
+      tabBarScrollerPresent: true
+    };
+  }
+
+  mdcComponentInit() {
+    super.mdcComponentInit();
+    this.forceUpdate();
+  }
+}
 export default TabBar;

--- a/src/Tabs/tabs.story.js
+++ b/src/Tabs/tabs.story.js
@@ -5,41 +5,71 @@ import { action } from '@storybook/addon-actions';
 import { number } from '@storybook/addon-knobs';
 import { Tab, TabBar, TabBarScroller } from './';
 import { Button } from '../Button';
+import { Checkbox } from '../Checkbox';
 
 class TabBarStory extends React.Component {
 	state = {
+		withScroller: false,
 		count: 0,
 		activeTabIndex: 0,
 		tabs: ['Cookies', 'Pizza', 'Icecream']
 	};
+
+
+	onToggleWithScroller(evt) {
+		this.setState({ withScroller: !this.state.withScroller });
+		action('withScroller: ' + !this.state.withScroller)();
+	}
 
 	onChange(evt) {
 		this.setState({ activeTabIndex: evt.target.value });
 		action('activeTabIndex: ' + evt.target.value)();
 	}
 	onChangeTabNames(evt) {
-		this.setState({
+		const state = {
 			tabs: this.state.tabs.map((label, index) => index),
 			count: this.state.count + 1
-		});
+		};
+		this.setState(state);
+		action('onChangeTabNames: ' + JSON.stringify(state))();
 	}
 	onAddTab(evt) {
-		this.setState({
+		const state = {
 			tabs: [
 				...this.state.tabs,
 				`Dynamic Tab #${this.state.tabs.length + 1}`
 			]
-		});
+		};
+
+		this.setState(state);
+
+		action('onAddTab: ' + JSON.stringify(state))();
 	}
 	onRemoveLastTab(evt) {
 		const init = this.state.tabs.slice(0, -1);
-		this.setState({
+		const state = {
 			activeTabIndex: 0,
 			tabs: init
-		});
+		};
+
+		this.setState(state);
+		action('onRemoveLastTab: ' + JSON.stringify(state))();
 	}
 
 	render() {
+
+		const tabBar = <TabBar
+			count={this.state.count}
+			activeTabIndex={number(
+				'activeTabIndex',
+				this.state.activeTabIndex
+			)}
+			onChange={evt => this.onChange(evt)}>
+			{this.state.tabs.map(label => <Tab key={label}>{label}</Tab>)}
+		</TabBar>;
+
+		const finalComponent = this.state.withScroller ? <TabBarScroller>{tabBar}</TabBarScroller> : tabBar;
+
 		return (
 			<div >
 				<div style={{ width: '50%', maxWidth: '480px', display: 'flex', flexWrap: 'wrap', justifyContent: 'space-between' }}>
@@ -55,16 +85,11 @@ class TabBarStory extends React.Component {
 						onClick={evt => this.onRemoveLastTab(evt)}>
 						Remove Last Tab
 					</Button>
+					<Checkbox onChange={evt => this.onToggleWithScroller(evt)}>
+						with TabBarScroller
+					</Checkbox>
 				</div>
-				<TabBar
-					count={this.state.count}
-					activeTabIndex={number(
-						'activeTabIndex',
-						this.state.activeTabIndex
-					)}
-					onChange={evt => this.onChange(evt)}>
-					{this.state.tabs.map(label => <Tab key={label}>{label}</Tab>)}
-				</TabBar>
+				{finalComponent}
 			</div>
 		);
 	}


### PR DESCRIPTION
Fixes #73.

A foundation instance (MDCTabBar) must be passed from MDCTabBarScroller to the enclosed TabBar component.

The TabBar component will check if it's contained within TabBarScroller by searching for 'mdc-tab-bar-scroller' class up the hierarchy. If detected TabBar will create a dummy MDCComponent instance during construction. The second instance of MDCTabBar created by MDCTabBarScroller will replace the dummy instance through the apiRef hook (provided by withTabBarApi hoc) in TabBar::onUpdate.






