### PR TITLE
fix(Select): Don't show first option if value = null

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -175,7 +175,10 @@ export const Select = withMDC({
       isFirstRun ||
       placeholderDidChange
     ) {
-      const newIndex = api.options.indexOf(api.nameditem(nextProps.value));
+      // if value = null, MDC will show the first option. This behaviour is not desired
+      let value = nextProps.value === null ? undefined : nextProps.value;
+
+      const newIndex = api.options.indexOf(api.nameditem(value));
       api.selectedIndex =
         newIndex === -1 && nextProps.placeholder ? 0 : newIndex;
 

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -176,7 +176,7 @@ export const Select = withMDC({
       placeholderDidChange
     ) {
       // if value = null, MDC will show the first option. This behaviour is not desired
-      let value = nextProps.value === null ? undefined : nextProps.value;
+      const value = nextProps.value === null ? undefined : nextProps.value;
 
       const newIndex = api.options.indexOf(api.nameditem(value));
       api.selectedIndex =


### PR DESCRIPTION
PR to the discussion in #104. Need to figure out the desired behavior first. I will change this PR in case that changes to something other than showing the label / placeholder for value = null. 