### PR TITLE
fix(Tabs): HOC Tab Initialization loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Webstorm
+.idea

--- a/src/Tabs/index.js
+++ b/src/Tabs/index.js
@@ -147,10 +147,7 @@ export const TabBar: React.ComponentType<TabBarPropsT> = withMDC({
       JSON.stringify(props.children.map(({ key }) => key)) !==
         JSON.stringify(nextProps.children.map(({ key }) => key));
 
-    const tabsLengthMismatch =
-      React.Children.toArray(nextProps.children).filter(
-        c => c.type.displayName === 'Tab'
-      ).length !== api.tabs.length;
+    const tabsLengthMismatch = React.Children.toArray(nextProps.children).length !== api.tabs.length;
 
     // Children changing is a pain...
     // We have to perform a lot of cleanup and sometimes we have to reinit


### PR DESCRIPTION
`Tab` being wrapped by an `HOC` like `styled-components` causing an Initialization loop because it's `displayName !== 'Tab'`.

Resolves #116