### PR TITLE
feat(GridList): add GridTileIcon

### DIFF
--- a/src/GridList/grid-list.md
+++ b/src/GridList/grid-list.md
@@ -9,6 +9,7 @@ import from **rmwc/GridList**
 import {
   GridList,
   GridTile,
+  GridTileIcon,
   GridTilePrimary,
   GridTilePrimaryContent,
   GridTileSecondary,
@@ -33,6 +34,7 @@ import { Select } from 'rmwc/Select';
         </GridTilePrimaryContent>
       </GridTilePrimary>
       <GridTileSecondary>
+        <GridTileIcon>info</GridTileIcon>
         <GridTileTitle>Tile {i + 1}</GridTileTitle>
       </GridTileSecondary>
     </GridTile>
@@ -57,6 +59,7 @@ import { DocumentComponent } from 'rmwc/Base/DocumentComponent';
 
 <DocumentComponent displayName="GridList" />
 <DocumentComponent displayName="GridTile" />
+<DocumentComponent displayName="GridTileIcon" />
 <DocumentComponent displayName="GridTilePrimary" />
 <DocumentComponent displayName="GridTileSecondary" />
 <DocumentComponent displayName="GridTileTitleSupportText" />

--- a/src/GridList/grid-list.spec.js
+++ b/src/GridList/grid-list.spec.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import {
 	GridList,
 	GridTile,
+	GridTileIcon,
 	GridTilePrimary,
 	GridTilePrimaryContent,
 	GridTileSecondary,
@@ -20,6 +21,7 @@ describe('GridList', () => {
 						</GridTilePrimaryContent>
 					</GridTilePrimary>
 					<GridTileSecondary>
+						<GridTileIcon>info</GridTileIcon>
 						<GridTileTitle>Tile</GridTileTitle>
 					</GridTileSecondary>
 				</GridTile>
@@ -46,6 +48,7 @@ describe('GridList', () => {
 		[
 			GridList,
 			GridTile,
+			GridTileIcon,
 			//GridTilePrimary,	Apparently these cant have custom classes, look into why
 			//GridTilePrimaryContent,
 			GridTileSecondary,

--- a/src/GridList/grid-list.story.js
+++ b/src/GridList/grid-list.story.js
@@ -10,6 +10,7 @@ import {
   GridTilePrimaryContent,
   GridTileSecondary,
   GridTileTitle,
+  GridTileIcon
 } from './';
 
 const cells = Array(24).fill();
@@ -46,6 +47,7 @@ storiesOf('GridLists', module).add('Grid List', () => {
               </GridTilePrimaryContent>
             </GridTilePrimary>
             <GridTileSecondary>
+              <GridTileIcon>info</GridTileIcon>
               <GridTileTitle>Tile {i + 1}</GridTileTitle>
             </GridTileSecondary>
           </GridTile>

--- a/src/GridList/index.js
+++ b/src/GridList/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import Icon from '../Icon';
 import { simpleTag } from '../Base';
 import type { SimpleTagPropsT } from '../Base';
 
@@ -90,6 +91,13 @@ export const GridTileSecondary = simpleTag({
   displayName: 'GridTileSecondary',
   tag: 'span',
   classNames: 'mdc-grid-tile__secondary'
+});
+
+/** The icon for a Grid tile. This is an instance of Icon and can take all of the same props. */
+export const GridTileIcon = simpleTag({
+  displayName: 'GridTileIcon',
+  tag: Icon,
+  classNames: 'mdc-grid-tile__icon'
 });
 
 /** The title for a Grid tile */


### PR DESCRIPTION
Adds a `<GridTileIcon>` component to take advantage of the `withIconAlignStart` prop on `<GridList>`. It uses the existing `<Icon>` component and adds the MDC class `mdc-grid-tile__icon` to the element.