### PR TITLE
Sync validality status with TextField Foundation

### DIFF
--- a/src/TextField/index.js
+++ b/src/TextField/index.js
@@ -181,6 +181,15 @@ export const TextField = withMDC({
     ) {
       inst.mdcComponentReinit();
     }
+    if (
+      props &&
+      (props.invalid !== nextProps.invalid)
+    ) {
+      api.foundation_.setValid(!nextProps.invalid);
+    }
+  },
+  onMount: (props, api, inst) => {
+    api.foundation_.setValid(!props.invalid);
   }
 })(
   class extends React.Component<TextFieldPropsT> {

--- a/src/TextField/textfield.spec.js
+++ b/src/TextField/textfield.spec.js
@@ -71,4 +71,19 @@ describe('TextField', () => {
   it('can be required', () => {
     mount(<TextField required />);
   });
+
+  it('sync validlity with textfield foundation during prop initialization', () => {
+    let inst = mount(<TextField invalid />).instance();
+    expect(inst.mdcApi.foundation_.isValid()).toBe(false);
+    inst = mount(<TextField invalid={false} />).instance();
+    expect(inst.mdcApi.foundation_.isValid()).toBe(true);
+  });
+
+  it('sync validlity with textfield foundation during prop modification', () => {
+    const wrapper = mount(<TextField invalid />);
+    const inst = wrapper.instance();
+    expect(inst.mdcApi.foundation_.isValid()).toBe(false);
+    wrapper.setProps({ invalid: false });
+    expect(inst.mdcApi.foundation_.isValid()).toBe(true);
+  });
 });


### PR DESCRIPTION
Beforehand, the invalid prop in the react component is not synced with TextField Foundation