### PR TITLE
docs(Dialog): Missing props and descriptions

### DIFF
--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -41,8 +41,14 @@ export const DialogHeaderTitle = simpleTag({
   classNames: 'mdc-dialog__header__title'
 });
 
+
+type DialogBodyT = {
+  /** Make it scrollable. */
+  scrollable?: boolean
+} & SimpleTagPropsT;
+
 /** The Dialog body */
-export const DialogBody = simpleTag({
+export class DialogBody extends simpleTag({
   displayName: 'DialogBody',
   tag: 'section',
   classNames: props => [
@@ -52,7 +58,11 @@ export const DialogBody = simpleTag({
     }
   ],
   consumeProps: ['scrollable']
-});
+})<DialogBodyT> {
+  render() {
+    return super.render();
+  }
+}
 
 /** The Dialog footer */
 export const DialogFooter = simpleTag({

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -72,9 +72,9 @@ export const DialogFooter = simpleTag({
 });
 
 type DialogFooterButtonT = {
-  /* Make it an accept Button. */
+  /** Make it an accept button. */
   accept?: boolean,
-  /* Make it a cancel button. */
+  /** Make it a cancel button. */
   cancel?: boolean
 } & SimpleTagPropsT;
 

--- a/src/docs/docgen.json
+++ b/src/docs/docgen.json
@@ -370,14 +370,14 @@
             "name": "boolean"
           },
           "required": false,
-          "description": ""
+          "description": "Make it an accept button."
         },
         "cancel": {
           "flowType": {
             "name": "boolean"
           },
           "required": false,
-          "description": ""
+          "description": "Make it a cancel button."
         }
       }
     },

--- a/src/docs/docgen.json
+++ b/src/docs/docgen.json
@@ -344,20 +344,16 @@
     {
       "description": "The Dialog body",
       "displayName": "DialogBody",
-      "methods": [
-        {
-          "name": "classNames",
-          "docblock": null,
-          "modifiers": [],
-          "params": [
-            {
-              "name": "props",
-              "type": null
-            }
-          ],
-          "returns": null
+      "methods": [],
+      "props": {
+        "scrollable": {
+          "flowType": {
+            "name": "boolean"
+          },
+          "required": false,
+          "description": "Make it scrollable."
         }
-      ]
+      }
     },
     {
       "description": "The Dialog footer",


### PR DESCRIPTION
I noticed a couple of missing details in the documentation for the Dialog components. In particular, the `scrollable` prop for the DialogBody was not shown and the descriptions for the DialogFooterButton props were missing. This adds a flow type definition for the DialogBody and fixes a couple small typos in the DialogFooterButton prop type descriptions

