### PR TITLE
fix(textfield): add mdc class on disabled textfields

### DIFF
--- a/src/TextField/index.js
+++ b/src/TextField/index.js
@@ -32,10 +32,11 @@ export const TextFieldRoot: React.ComponentType<
       'mdc-text-field--box': props.box,
       'mdc-text-field--outlined': props.outlined,
       'mdc-text-field--dense': props.dense,
-      'mdc-text-field--invalid': props.invalid
+      'mdc-text-field--invalid': props.invalid,
+      'mdc-text-field--disabled': props.disabled,
     }
   ],
-  consumeProps: ['textarea', 'box', 'fullwidth', 'outlined', 'dense', 'invalid']
+  consumeProps: ['textarea', 'box', 'fullwidth', 'outlined', 'dense', 'invalid', 'disabled']
 });
 
 export const TextFieldLabel = simpleTag({
@@ -205,6 +206,7 @@ export const TextField = withMDC({
         fullwidth,
         dense,
         invalid,
+        disabled,
         withLeadingIcon,
         withTrailingIcon,
         mdcElementRef,
@@ -249,6 +251,7 @@ export const TextField = withMDC({
           textarea={textarea}
           box={box}
           dense={dense}
+          disabled={disabled}
           outlined={outlined}
           fullwidth={fullwidth}
           elementRef={mdcElementRef}

--- a/src/TextField/index.js
+++ b/src/TextField/index.js
@@ -223,9 +223,9 @@ export const TextField = withMDC({
       };
 
       const tag = textarea ? (
-        <TextFieldTextarea {...tagProps} />
+        <TextFieldTextarea disabled={disabled} {...tagProps} />
       ) : (
-        <TextFieldInput {...tagProps} />
+        <TextFieldInput disabled={disabled} {...tagProps} />
       );
 
       // handle leading and trailing icons

--- a/src/TextField/index.js
+++ b/src/TextField/index.js
@@ -218,14 +218,15 @@ export const TextField = withMDC({
 
       const tagProps = {
         ...rest,
+        disabled: disabled,
         elementRef: inputRef,
         id: rest.id || randomId('text-field')
       };
 
       const tag = textarea ? (
-        <TextFieldTextarea disabled={disabled} {...tagProps} />
+        <TextFieldTextarea {...tagProps} />
       ) : (
-        <TextFieldInput disabled={disabled} {...tagProps} />
+        <TextFieldInput {...tagProps} />
       );
 
       // handle leading and trailing icons


### PR DESCRIPTION
When using the disabled property on textfield `mdc-text-field--disabled` should be added as a className. Fixes issue #147 