### PR TITLE
Fix ThemeProvider example in docs

### DIFF
--- a/src/docs/App.js
+++ b/src/docs/App.js
@@ -246,12 +246,12 @@ class ThemePicker extends React.Component {
                 </div>
                 <span className="token keyword">import</span> {'{'}{' '}
                 ThemeProvider {'}'} <span className="token keyword">from</span>{' '}
-                <span className="token string">'rmwc/ThemeProvider';</span>
+                <span className="token string">'rmwc/Theme';</span>
                 <br />
                 <br />
                 <span className="token punctuation">&lt;</span>
                 <span className="token tag">ThemeProvider </span>
-                <span className="token attr-name">options</span>={'{'}
+                <span className="token attr-name">options</span>={'{{'}
                 {Object.entries(selectedTheme).map(([t, val], index, arr) => (
                   <div
                     key={t}
@@ -271,7 +271,7 @@ class ThemePicker extends React.Component {
                     <ColorBlock color={val} size="1" />
                   </div>
                 ))}
-                {'}'}
+                {'}}'}
                 <span className="token punctuation">&gt;</span>
                 <br />
                 &nbsp;&nbsp;<span className="token punctuation">&lt;</span>


### PR DESCRIPTION
Currently the ThemeProvider example code shown in the TopAppBar of the docs is broken. It's missing the secondary braces and still imports from `rmwc/ThemeProvider` which - i guess - was moved to `rmwc/Theme`.