### PR TITLE
fix(TopAppBar): Corrects alignStart style for TopAppBarSection

### DIFF
--- a/src/top-app-bar/index.js
+++ b/src/top-app-bar/index.js
@@ -57,7 +57,7 @@ const TopAppBarSectionRoot = simpleTag({
   classNames: (props: TopAppBarSectionPropsT) => [
     'mdc-top-app-bar__section',
     {
-      'mdc-top-app-bar__section--align-Start': props.alignStart,
+      'mdc-top-app-bar__section--align-start': props.alignStart,
       'mdc-top-app-bar__section--align-end': props.alignEnd
     }
   ],


### PR DESCRIPTION
This PR corrects a typo in TopAppBarSection's className when alignStart=true so that proper style is applied.