### PR TITLE
Fix #259 Select will no longer ignore defaultValue

### DIFF
--- a/src/select/index.js
+++ b/src/select/index.js
@@ -138,6 +138,7 @@ export class Select extends withFoundation({
       placeholder,
       children,
       value,
+      defaultValue = '',
       outlined,
       label = '',
       options = [],
@@ -162,7 +163,7 @@ export class Select extends withFoundation({
         <SelectNativeControl
           {...rest}
           value={value}
-          defaultValue={value !== undefined ? undefined : ''}
+          defaultValue={value !== undefined ? undefined : defaultValue}
         >
           {(!!placeholder || placeholder === '') && (
             <option value="" disabled={placeholder === ''}>


### PR DESCRIPTION
Currently if value has been set rmwc will set defaultValue to undefined, otherwise it will set it to '', effectively meaning defaultValue is ignored.

By default React throws an error if the user defines both value and defaultValue, so rmwc shouldn't have to deal with this.