### PR TITLE
use SnackbarPropsT in syncWithProps parameter

### DIFF
--- a/src/snackbar/index.js
+++ b/src/snackbar/index.js
@@ -115,15 +115,15 @@ export class Snackbar extends withFoundation({
     this.isShowing_ = isShowing;
   }
 
-  syncWithProps(nextProps: MDCSnackbar) {
+  syncWithProps(nextProps: SnackbarPropsT) {
     syncFoundationProp(
       nextProps.dismissesOnAction,
       this.dismissesOnAction,
-      () => (this.dismissesOnAction = nextProps.dismissesOnAction)
+      () => (this.dismissesOnAction = !!nextProps.dismissesOnAction)
     );
 
     syncFoundationProp(nextProps.show, this.isShowing, () => {
-      this.isShowing = nextProps.show;
+      this.isShowing = !!nextProps.show;
 
       window.requestAnimationFrame(() => {
         if (nextProps.show) {


### PR DESCRIPTION
Relates to issue https://github.com/jamesmfriedman/rmwc/issues/345 

Warning: I don't know if this breaks anything. It looks reasonable to me but it's meant to be illustrative of my comment: https://github.com/jamesmfriedman/rmwc/issues/345#issuecomment-431858170

The `!!` are added to turn the type from `undefined | boolean` to just `boolean`.

Though it does build correctly.