### PR TITLE
fix(TextField): Don't sync empty strings.

### DIFF
--- a/src/textfield/index.js
+++ b/src/textfield/index.js
@@ -244,7 +244,7 @@ export class TextField extends FoundationComponent<TextFieldPropsT> {
   }
 
   sync(props: TextFieldPropsT) {
-    if (props.value !== undefined) {
+    if (props.value) {
       this.foundation_.setValue(props.value);
     }
   }


### PR DESCRIPTION
When using a `TextField` with validation - such as `required` - it will render as invalid immediately due to the initial `sync` of an empty string, which is not the correct behaviour. The simplest fix seems to be changing `sync` to only call `setValue` for non-empty strings.

This relates to issue 280 and 297 (which seems to be a relatively recent regression.)