### PR TITLE
fix(Menu): Set aria-hidden dynamically for A11Y

### DIFF
--- a/src/menu/index.js
+++ b/src/menu/index.js
@@ -65,8 +65,7 @@ export const MenuItems = simpleTag({
   tag: List,
   classNames: 'mdc-list mdc-menu__items',
   defaultProps: {
-    role: 'menu',
-    'aria-hidden': 'true'
+    role: 'menu'
   }
 });
 
@@ -167,7 +166,7 @@ export class Menu extends withFoundation({
     const { root_ } = this.foundationRefs;
 
     return (
-      <MenuRoot {...rest} elementRef={root_}>
+      <MenuRoot aria-hidden={!open} {...rest} elementRef={root_}>
         <MenuItems>{children}</MenuItems>
       </MenuRoot>
     );

--- a/src/menu/menu.spec.js
+++ b/src/menu/menu.spec.js
@@ -5,6 +5,7 @@ import {
   Menu,
   MenuSurface,
   MenuItem,
+  MenuRoot,
   SimpleMenu,
   SimpleMenuSurface
 } from './';
@@ -37,6 +38,20 @@ describe('Menu', () => {
     );
 
     expect(el.html().includes('mdc-menu-surface--fixed')).toBe(true);
+  });
+
+  it('dynamically updates aria-hidden based on whether or not the menu is open', () => {
+    let el = mount(
+      <Menu open />
+    );
+
+    expect(el.find(MenuRoot).prop('aria-hidden')).toBe(false);
+
+    el = mount(
+      <Menu />
+    );
+
+    expect(el.find(MenuRoot).prop('aria-hidden')).toBe(true);
   });
 
   it('MenuSurface renders', () => {


### PR DESCRIPTION
We use RMWC for some of our web applications, and it recently underwent an audit for ADA compliance. Some of our dropdown menus were flagged as improperly using the aria-hidden attribute, as it was set to true regardless of whether or not the menu was open, and contained nested elements which were subsequently ignored by screen readers.

This PR fixes aria-hidden for the Menu component.

Here's the violation in our web app:

<img width="1680" alt="screen shot 2018-11-16 at 2 24 14 pm" src="https://user-images.githubusercontent.com/16148766/48653769-5b51a180-e9bc-11e8-934e-36c212d85d55.png">

After fix:

<img width="1449" alt="screen shot 2018-11-18 at 4 16 35 pm" src="https://user-images.githubusercontent.com/16148766/48680330-2de92d00-eb4f-11e8-8954-b05b55a688cd.png">
<img width="1625" alt="screen shot 2018-11-18 at 4 16 27 pm" src="https://user-images.githubusercontent.com/16148766/48680331-2de92d00-eb4f-11e8-8523-36ba56b60a0e.png">
