### PR TITLE
Add support for id and for attributes

### DIFF
--- a/src/select/index.js
+++ b/src/select/index.js
@@ -158,9 +158,9 @@ export class Select extends withFoundation({
       ...rest
     } = this.props;
 	
-	if(!options.id) {
-		options.id = randomId('select');
-	}
+    if(!options.id) {
+      options.id = randomId('select');
+    }
 
     const { root_ } = this.foundationRefs;
     const selectOptions = createSelectOptions(options);
@@ -175,7 +175,7 @@ export class Select extends withFoundation({
       >
         <SelectNativeControl
           {...rest}
-		  id={options.id}
+          id={options.id}
           value={value}
           defaultValue={
             value !== undefined ? undefined : this.props.defaultValue || ''

--- a/src/select/index.js
+++ b/src/select/index.js
@@ -2,7 +2,7 @@
 import type { SimpleTagPropsT } from '@rmwc/base';
 import * as React from 'react';
 import { MDCSelect } from '@material/select/dist/mdc.select';
-import { simpleTag, withFoundation, syncFoundationProp } from '@rmwc/base';
+import { simpleTag, withFoundation, syncFoundationProp, randomId } from '@rmwc/base';
 import { FloatingLabel } from '@rmwc/floating-label';
 import { LineRipple } from '@rmwc/line-ripple';
 import { NotchedOutline, NotchedOutlineIdle } from '@rmwc/notched-outline';
@@ -157,6 +157,10 @@ export class Select extends withFoundation({
       style,
       ...rest
     } = this.props;
+	
+	if(!options.id) {
+		options.id = randomId('select');
+	}
 
     const { root_ } = this.foundationRefs;
     const selectOptions = createSelectOptions(options);
@@ -171,6 +175,7 @@ export class Select extends withFoundation({
       >
         <SelectNativeControl
           {...rest}
+		  id={options.id}
           value={value}
           defaultValue={
             value !== undefined ? undefined : this.props.defaultValue || ''
@@ -203,7 +208,7 @@ export class Select extends withFoundation({
             })}
           {children}
         </SelectNativeControl>
-        <FloatingLabel>{label}</FloatingLabel>
+        <FloatingLabel htmlFor={options.id}>{label}</FloatingLabel>
         {!!outlined && <NotchedOutline />}
         {!!outlined ? <NotchedOutlineIdle /> : <LineRipple />}
       </SelectRoot>


### PR DESCRIPTION
To activate the select on clicking the corresponding label, the label needs to have a for attribute with a matching id. Either by setting a random id, or providing one to the select.