### PR TITLE
5.x Fixes typo in Collapsible List css path

### DIFF
--- a/src/list/README-COLLAPSIBLE.md
+++ b/src/list/README-COLLAPSIBLE.md
@@ -5,7 +5,7 @@
 - import from **'@rmwc/list'**;
 - Import styles:
   - import **'@material/list/dist/mdc.list.css'**;
-  - import **'@material/list/collapsible-list.css'**;
+  - import **'@rmwc/list/collapsible-list.css'**;
 
 Collapsible lists aren't part of the material spec, but they've been added to RMWC after continuing requests from the community. They present an accordion style navigation element to progressively reveal content. They've have been built to work with the `List` and `ListItem` components in regards to keyboard events and styling, but they technically be used with any kind of content.
 


### PR DESCRIPTION
I'm assuming this needs to be fixed...