### PR TITLE
5.x Adds consumeProps to CollapsibleList

### DIFF
--- a/src/list/collapsible-list.tsx
+++ b/src/list/collapsible-list.tsx
@@ -20,7 +20,8 @@ interface CollapsibleState {
 
 const CollapsibleRoot = componentFactory<{}>({
   displayName: 'CollapsibleRoot',
-  classNames: ['rmwc-collapsible-list']
+  classNames: ['rmwc-collapsible-list'],
+  consumeProps: ['handle','open','onOpen','onClose']
 });
 
 const possiblyFocusElement = (el: Element | null) => {


### PR DESCRIPTION
I was getting a `Warning: Unknown event handler property 'onOpen'. It will be ignored.` I'm assuming all those props need to be consumed for the root component?

Still not very familair with the typescript rewrite so I could be missing more...