### PR TITLE
fix(Snackbar): Add missing icon-button dependency

### DIFF
--- a/src/snackbar/package.json
+++ b/src/snackbar/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "@material/snackbar": "^0.44.0",
     "@rmwc/base": "^5.1.8",
-    "@rmwc/button": "^5.1.8"
+    "@rmwc/button": "^5.1.8",
+    "@rmwc/icon-button": "^5.1.8"
   },
   "gitHead": "41bbd3e5cb78bd672ee6a855b5407fbe37a7f815"
 }


### PR DESCRIPTION
As of v5.0.0 (specifically e8b617d) — the `<Snackbar />` imports and uses the `<IconButton />` for the `dismissIcon` prop, but `@rmwc/icon-button` was never added to the list of dependencies for `@rmwc/snackbar`. This PR adds the latest version to the dependencies list.