### PR TITLE
fix(textfield): Add mdc-text-field-helper-line wrapper

### DIFF
--- a/src/textfield/index.tsx
+++ b/src/textfield/index.tsx
@@ -298,14 +298,14 @@ export class TextField extends FoundationComponent<
       typeof helpText === 'object' && !React.isValidElement(helpText);
 
     return (
-      <div className="mdc-text-field-helper-line">
+      <React.Fragment>
         {helpText && shouldSpread ? (
           <TextFieldHelperText {...helpText as any} />
         ) : (
           <TextFieldHelperText>{helpText}</TextFieldHelperText>
         )}
         {!textarea && renderedCharacterCounter}
-      </div>
+      </React.Fragment>
     );
   }
 
@@ -503,7 +503,14 @@ export const TextFieldHelperText = componentFactory<TextFieldHelperTextProps>({
       'mdc-text-field-helper-text--validation-msg': props.validationMsg
     }
   ],
-  consumeProps: ['persistent', 'validationMsg']
+  consumeProps: ['persistent', 'validationMsg'],
+  render: (props, ref, Tag) => {
+    return (
+      <div className='mdc-text-field-helper-line'>
+        <Tag ref={ref} {...props} />
+      </div>
+    )
+  }
 });
 
 /*********************************************************************

--- a/src/textfield/textfield.spec.tsx
+++ b/src/textfield/textfield.spec.tsx
@@ -178,4 +178,22 @@ describe('TextFieldHelperText', () => {
   it('renders', () => {
     mount(<TextFieldHelperText>Hello</TextFieldHelperText>);
   });
+
+  it('sets the correct classNames', () => {
+    const el = mount(<TextFieldHelperText>Hello</TextFieldHelperText>);
+    expect(el.html().includes('mdc-text-field-helper-line')).toBe(true);
+    expect(el.html().includes('mdc-text-field-helper-text')).toBe(true);
+  })
+
+  it('uses the props', () => {
+    const el = mount(
+      <TextFieldHelperText persistent validationMsg>Hello</TextFieldHelperText>
+    );
+    expect(
+      el.html().includes('mdc-text-field-helper-text--persistent')
+    ).toBe(true);
+    expect(
+      el.html().includes('mdc-text-field-helper-text--validation-msg')
+    ).toBe(true);
+  })
 });


### PR DESCRIPTION
Previously, the `<TextField helpText={{...}} />` rendered the `<TextFieldHelperText />` with the surrounding `mdc-text-field-helper-line` `<div>` (as per the [Material Web Components spec](https://material.io/develop/web/components/input-controls/text-field/helper-text/#html-structure)) — but you wouldn't get the wrapper `<div>` if you rendered the standalone `<TextFieldHelperText />`.

This PR move the wrapper to the standalone helper component and updates the specs to test for this. I used the `render` property from the `componentFactory()` to just add the wrapper `<div>` as that seemed simplest.