### PR TITLE
add trailing icon example

### DIFF
--- a/src/button/README.md
+++ b/src/button/README.md
@@ -17,6 +17,10 @@ import { CircularProgress } from '@rmwc/circular-progress';
   icon="favorite"
 />
 <Button
+  label="With Trailing Icon"
+  trailingIcon="favorite"
+/>
+<Button
   label="Raised"
   raised
 />

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -14,7 +14,7 @@ export interface ButtonProps extends RMWC.WithRippleProps {
   unelevated?: boolean;
   /** Make the button outlined. */
   outlined?: boolean;
-  /** make the button disabled */
+  /** Make the button disabled */
   disabled?: boolean;
   /** Content specified as a label prop. */
   label?: React.ReactNode | any;


### PR DESCRIPTION
An example for the trailing icon wasn't in the docs. Therefore I thought as a user that this possibility is not officially supported.

This PR adds it to the docs.