### PR TITLE
Fix dialog, linear-progress and select module names in docs

### DIFF
--- a/src/dialog/readme.tsx
+++ b/src/dialog/readme.tsx
@@ -20,7 +20,7 @@ export default function() {
     <Docs
       title="Dialogs"
       lead="Dialogs inform users about a specific task and may contain critical information, require decisions, or involve multiple tasks."
-      module="@rmwc/- Module **@rmwc/dialog**"
+      module="@rmwc/dialog"
       styles={[
         '@material/dialog/dist/mdc.dialog.css',
         '@material/button/dist/mdc.button.css'

--- a/src/linear-progress/readme.tsx
+++ b/src/linear-progress/readme.tsx
@@ -11,7 +11,7 @@ export default function() {
     <Docs
       title="Linear Progress"
       lead="Progress and activity indicators are visual indications of an app loading content."
-      module="@rmwc/fab"
+      module="@rmwc/linear-progress"
       styles={['@material/linear-progress/dist/mdc.linear-progress.css']}
       docsLink="https://material.io/develop/web/components/linear-progress/"
       examples={examples}

--- a/src/select/readme.tsx
+++ b/src/select/readme.tsx
@@ -11,7 +11,7 @@ export default function() {
     <Docs
       title="Select Menus"
       lead="Menus display a list of choices on a transient sheet of material."
-      module="@rmwc/fab"
+      module="@rmwc/select"
       styles={[
         '@material/select/dist/mdc.select.css',
         '@material/floating-label/dist/mdc.floating-label.css',


### PR DESCRIPTION
The module names in the new docs for **dialog**, **linear-progress** and **select** seem to be incorrect.

Corrected them to **@rmwc/dialog**, **@rmwc/linear-progress** and **@rmwc/select**.