### PR TITLE
docs(Menu): Remove duplicated SimpleMenu docs

### DIFF
--- a/src/menu/README.md
+++ b/src/menu/README.md
@@ -191,22 +191,3 @@ A Simplified menu component that allows you to pass a handle element and will au
 | `rootProps` | `Object` | By default, props spread to the Menu component. These will spread to the MenuSurfaceAnchor which is useful for things like overall positioning of the anchor. |
 
 
-## SimpleMenu
-A Simplified menu component that allows you to pass a handle element and will automatically control the open state and add a MenuSurfaceAnchor
-
-### Props
-
-| Name | Type | Description |
-|------|------|-------------|
-| `anchorCorner` | `AnchorT` | Manually position the menu to one of the corners. |
-| `children` | `React.ReactNode` | Children to render |
-| `fixed` | `undefined \| false \| true` | Make the menu position fixed. |
-| `handle` | `ReactElement<any>` | An element that will open the menu when clicked |
-| `hoistToBody` | `undefined \| false \| true` | Moves the menu to the body. Useful for situations where the content might be cutoff by an overflow: hidden container. |
-| `onClose` | `undefined \| (evt: RMWC.CustomEventT<{}>) => void` | Callback for when the menu is closed. |
-| `onOpen` | `undefined \| (evt: RMWC.CustomEventT<{}>) => void` | Callback for when the menu is opened. |
-| `onSelect` | `undefined \| (evt: RMWC.CustomEventT<>) => void` | Callback that fires when a Menu item is selected. |
-| `open` | `undefined \| false \| true` | Opens the menu. |
-| `rootProps` | `Object` | By default, props spread to the Menu component. These will spread to the MenuSurfaceAnchor which is useful for things like overall positioning of the anchor. |
-
-


### PR DESCRIPTION
As pointed out by @dohomi the docs of the SimpleMenu component are duplicated. This PR only leaves one version behind. 
The duplication was introduced by the big documentation update.