### PR TITLE
fix(Dialog|Snackbar): broken dialog and snackbar types

### DIFF
--- a/src/dialog/dialog-queue.tsx
+++ b/src/dialog/dialog-queue.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { SimpleDialog, SimpleDialogProps, DialogOnCloseEventT } from './dialog';
 import { ArrayEmitter, randomId } from '@rmwc/base';
 import { TextField, TextFieldProps } from '@rmwc/textfield';

--- a/src/snackbar/snackbar-queue.tsx
+++ b/src/snackbar/snackbar-queue.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   Snackbar,
   SnackbarProps,


### PR DESCRIPTION
* `import * as React from 'react'` syntax needs to be used to avoid breaking consumers

Fixes - https://github.com/jamesmfriedman/rmwc/issues/465