### PR TITLE
support react useRef with @rwmc's inputRef

### DIFF
--- a/src/checkbox/checkbox.spec.tsx
+++ b/src/checkbox/checkbox.spec.tsx
@@ -49,4 +49,19 @@ describe('Checkbox', () => {
     const el = mount(<Checkbox className={'my-custom-classname'} />);
     expect(!!~el.html().search('my-custom-classname')).toEqual(true);
   });
+
+  it('supports inputRef as an object reference', () => {
+    const inputObjectRef: any = { current: null };
+    mount(<Checkbox inputRef={inputObjectRef} />);
+    expect(inputObjectRef.current instanceof HTMLInputElement).toBeTruthy();
+  });
+
+  it('supports inputRef as a function reference', () => {
+    let inputObjectRef: any;
+    const objectRefFunc: any = (el: HTMLInputElement) => {
+      inputObjectRef = el;
+    };
+    mount(<Checkbox inputRef={objectRefFunc} />);
+    expect(inputObjectRef instanceof HTMLInputElement).toBeTruthy();
+  });
 });

--- a/src/checkbox/index.tsx
+++ b/src/checkbox/index.tsx
@@ -153,7 +153,11 @@ export class Checkbox extends ToggleableFoundationComponent<
           {...this.nativeCb.props(rest)}
           ref={(el: HTMLInputElement | null) => {
             this.nativeCb.setRef(el);
-            inputRef && inputRef(el);
+            if (typeof inputRef === 'function') {
+              inputRef && inputRef(el);
+            } else if (typeof inputRef === 'object') {
+              inputRef.current = el;
+            }
           }}
           id={this.id}
           onChange={this.handleOnChange}

--- a/src/switch/index.tsx
+++ b/src/switch/index.tsx
@@ -132,7 +132,11 @@ export class Switch extends ToggleableFoundationComponent<
               id={this.id}
               ref={(el: HTMLInputElement | null) => {
                 this.nativeControl.setRef(el);
-                inputRef && inputRef(el);
+                if (typeof inputRef === 'function') {
+                  inputRef && inputRef(el);
+                } else if (typeof inputRef === 'object') {
+                  inputRef.current = el;
+                }
               }}
             />
           </div>

--- a/src/switch/switch.spec.tsx
+++ b/src/switch/switch.spec.tsx
@@ -56,4 +56,19 @@ describe('Switch', () => {
     const el = mount(<Switch className={'my-custom-classname'} />);
     expect(!!~el.html().search('my-custom-classname')).toEqual(true);
   });
+
+  it('supports inputRef as an object reference', () => {
+    const inputObjectRef: any = { current: null };
+    mount(<Switch inputRef={inputObjectRef} />);
+    expect(inputObjectRef.current instanceof HTMLInputElement).toBeTruthy();
+  });
+
+  it('supports inputRef as a function reference', () => {
+    let inputObjectRef: any;
+    const objectRefFunc: any = (el: HTMLInputElement) => {
+      inputObjectRef = el;
+    };
+    mount(<Switch inputRef={objectRefFunc} />);
+    expect(inputObjectRef instanceof HTMLInputElement).toBeTruthy();
+  });
 });

--- a/src/textfield/index.tsx
+++ b/src/textfield/index.tsx
@@ -54,7 +54,9 @@ export interface TextFieldProps {
   /** By default, props spread to the input. These props are for the component's root container. */
   rootProps?: Object;
   /** A reference to the native input or textarea. */
-  inputRef?: (ref: HTMLInputElement | HTMLTextAreaElement | null) => void;
+  inputRef?:
+    | React.MutableRefObject<HTMLInputElement | HTMLTextAreaElement | null>
+    | ((ref: HTMLInputElement | HTMLTextAreaElement | null) => void);
   /** The type of input field to render, search, number, etc */
   type?: string;
 }
@@ -307,7 +309,7 @@ export class TextField extends FoundationComponent<
     return (
       <div className="mdc-text-field-helper-line">
         {helpText && shouldSpread ? (
-          <TextFieldHelperText {...helpText as any} />
+          <TextFieldHelperText {...(helpText as any)} />
         ) : (
           <TextFieldHelperText>{helpText}</TextFieldHelperText>
         )}
@@ -378,7 +380,11 @@ export class TextField extends FoundationComponent<
       disabled: disabled,
       ref: (ref: HTMLInputElement | HTMLTextAreaElement | null) => {
         this.input.setRef(ref);
-        inputRef && inputRef(ref);
+        if (typeof inputRef === 'function') {
+          inputRef && inputRef(ref);
+        } else if (typeof inputRef === 'object') {
+          inputRef.current = ref;
+        }
       },
       id: rest.id || this.generatedId
     };

--- a/src/textfield/textfield.spec.tsx
+++ b/src/textfield/textfield.spec.tsx
@@ -118,6 +118,25 @@ describe('TextField', () => {
     mount(<TextField trailingIcon="favorite" />);
   });
 
+  it('supports inputRef as an object reference', () => {
+    const textObjectRef: any = { current: null };
+    mount(<TextField inputRef={textObjectRef} />);
+    expect(textObjectRef.current instanceof HTMLInputElement).toBeTruthy();
+
+    const areaObjectRef: any = { current: null };
+    mount(<TextField inputRef={areaObjectRef} textarea />);
+    expect(areaObjectRef.current instanceof HTMLTextAreaElement).toBeTruthy();
+  });
+
+  it('supports inputRef as a function reference', () => {
+    let inputObjectRef: any;
+    const objectRefFunc: any = (el: HTMLInputElement) => {
+      inputObjectRef = el;
+    };
+    mount(<TextField inputRef={objectRefFunc} />);
+    expect(inputObjectRef instanceof HTMLInputElement).toBeTruthy();
+  });
+
   it('label floats on dynamic change', done => {
     const el = mount(<TextField label="test" value="" onChange={() => {}} />);
     expect(el.html().includes('mdc-floating-label--float-above')).toBe(false);

--- a/src/toggleable/index.tsx
+++ b/src/toggleable/index.tsx
@@ -17,7 +17,9 @@ export interface ToggleableFoundationProps {
   /** By default, all props except className and style spread to the input. These are additional props for the root of the checkbox. */
   rootProps?: React.HTMLProps<any>;
   /** A reference to the native input. */
-  inputRef?: (ref: HTMLInputElement | null) => void;
+  inputRef?:
+    | React.MutableRefObject<HTMLInputElement | null>
+    | ((ref: HTMLInputElement | null) => void);
 }
 
 export class ToggleableFoundationComponent<


### PR DESCRIPTION
fixes #475 

1) update inputRef's type to allow for react's `MutableRefObject` in addition to functional ref captures for textfield, switch and checkbox components
2) added tests to ensure passing in both types are supported