### PR TITLE
Fix "isMenuItems" check to not break on Symbol and string element types.

### DIFF
--- a/src/menu/menu.tsx
+++ b/src/menu/menu.tsx
@@ -58,6 +58,7 @@ export const MenuItem = componentFactory<MenuItemProps>({
 
 const isMenuItems = (child: React.ReactNode) =>
   React.isValidElement(child) &&
+  typeof (child as any).type === 'object' &&
   ('displayName' in (child as any).type && (child.type as any).displayName) ===
     'MenuItems';
 


### PR DESCRIPTION
This PR adds an extra check to `isMenuItems` function to take into consideration the `type` of the element being checked. Previous implementation was breaking on `Symbol` and `string` element types, when used like this:

```jsx
<Menu>
  {condition1 && (
    <React.Fragment>
      <Divider />
      <MenuItem />
    </React.Fragment>
  )}

  {condition2 && (
    <div>
      <Divider />
      <MenuItem />
    </div>
  )}
</Menu>
```

This would cause the `in` operator to be executed on values of type `Symbol` and `string` respectively.