### PR TITLE
Make z prop optional

### DIFF
--- a/src/elevation/index.tsx
+++ b/src/elevation/index.tsx
@@ -5,7 +5,7 @@ import { componentFactory, wrapChild } from '@rmwc/base';
 /** The Elevation Component */
 export interface ElevationProps {
   /** A number from 0 - 24 for different levels of elevation */
-  z: number | string;
+  z?: number | string;
   /** Allows for smooth transitions between elevations when the z value changes. */
   transition?: boolean;
   /** Allows the elevation classes to be merged onto the child component instead of creating an new DOM node. */


### PR DESCRIPTION
As I see, `z` has default value. IMHO it should be optional. With required mode I see false positive warnings in my IDE