### PR TITLE
Feat/dialog/include on opened on closed

### DIFF
--- a/src/dialog/dialog.spec.tsx
+++ b/src/dialog/dialog.spec.tsx
@@ -42,17 +42,21 @@ describe('Dialog', () => {
   });
 
   it('Dialog lifecycle', async done => {
+    let open = 0;
     let opened = 0;
+    let close = 0;
     let closed = 0;
     let lifecycle: string[] = [];
 
     const el = mount(
       <Dialog
-        onOpen={() => opened++}
+        onOpen={() => open++}
+        onOpened={() => opened++}
         onClose={() => {
-          closed++;
+          close++;
           el.setProps({ open: false });
         }}
+        onClosed={() => closed++}
         onStateChange={state => lifecycle.push(state)}
       >
         <DialogTitle>Dialog Title</DialogTitle>
@@ -77,7 +81,9 @@ describe('Dialog', () => {
     const cancelButton = el.find('button.mdc-dialog__button').first();
     cancelButton.simulate('click');
     await wait(250);
+    expect(open).toBe(2);
     expect(opened).toBe(2);
+    expect(close).toBe(2);
     expect(closed).toBe(2);
     expect(lifecycle).toEqual([
       'opening',

--- a/src/dialog/dialog.spec.tsx
+++ b/src/dialog/dialog.spec.tsx
@@ -46,7 +46,6 @@ describe('Dialog', () => {
     let opened = 0;
     let close = 0;
     let closed = 0;
-    let lifecycle: string[] = [];
 
     const el = mount(
       <Dialog
@@ -57,7 +56,6 @@ describe('Dialog', () => {
           el.setProps({ open: false });
         }}
         onClosed={() => closed++}
-        onStateChange={state => lifecycle.push(state)}
       >
         <DialogTitle>Dialog Title</DialogTitle>
 
@@ -85,16 +83,6 @@ describe('Dialog', () => {
     expect(opened).toBe(2);
     expect(close).toBe(2);
     expect(closed).toBe(2);
-    expect(lifecycle).toEqual([
-      'opening',
-      'opened',
-      'closing',
-      'closed',
-      'opening',
-      'opened',
-      'closing',
-      'closed'
-    ]);
     done();
   });
 

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -32,8 +32,6 @@ export interface DialogProps {
   onClose?: (evt: DialogOnCloseEventT) => void;
   /** Callback for when the Dialog finishes closing. evt.detail = { action?: string }*/
   onClosed?: (evt: DialogOnCloseEventT) => void;
-  /** Callback to use if you need more direct access to the Dialog's lifecycle. */
-  onStateChange?: (state: 'opening' | 'opened' | 'closing' | 'closed') => void;
   /** Prevent the dialog from closing when the scrim is clicked or escape key is pressed. */
   preventOutsideDismiss?: boolean;
   /** Advanced: A reference to the MDCFoundation. */
@@ -53,7 +51,6 @@ export const Dialog = createComponent<DialogProps>(function Dialog(props, ref) {
     onOpened,
     onClose,
     onClosed,
-    onStateChange,
     preventOutsideDismiss,
     foundationRef,
     'aria-labelledby': ariaLabelledby,

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -12,7 +12,9 @@ import { useDialogFoundation } from './foundation';
  *********************************************************************/
 
 export type DialogOnOpenEventT = RMWC.CustomEventT<{}>;
+export type DialogOnOpenedEventT = RMWC.CustomEventT<{}>;
 export type DialogOnCloseEventT = RMWC.CustomEventT<{ action?: string }>;
+export type DialogOnClosedEventT = RMWC.CustomEventT<{ action?: string }>;
 
 /*********************************************************************
  * Dialogs
@@ -24,8 +26,12 @@ export interface DialogProps {
   open?: boolean;
   /** Callback for when the Dialog opens. */
   onOpen?: (evt: DialogOnOpenEventT) => void;
-  /** Callback for when the Dialog closes. evt.detail = { action?: string }*/
+  /** Callback for when the Dialog finishes opening */
+  onOpened?: (evt: DialogOnOpenedEventT) => void;
+  /** Callback for when the Dialog beings to close. evt.detail = { action?: string }*/
   onClose?: (evt: DialogOnCloseEventT) => void;
+  /** Callback for when the Dialog finishes closing. evt.detail = { action?: string }*/
+  onClosed?: (evt: DialogOnCloseEventT) => void;
   /** Callback to use if you need more direct access to the Dialog's lifecycle. */
   onStateChange?: (state: 'opening' | 'opened' | 'closing' | 'closed') => void;
   /** Prevent the dialog from closing when the scrim is clicked or escape key is pressed. */
@@ -44,7 +50,9 @@ export const Dialog = createComponent<DialogProps>(function Dialog(props, ref) {
     children,
     open,
     onOpen,
+    onOpened,
     onClose,
+    onClosed,
     onStateChange,
     preventOutsideDismiss,
     foundationRef,

--- a/src/dialog/foundation.tsx
+++ b/src/dialog/foundation.tsx
@@ -79,22 +79,12 @@ export const useDialogFoundation = (
               button.parentElement && button.parentElement.appendChild(button)
           );
         },
-        notifyOpening: () => {
-          emit('onOpen', {});
-          getProps().onStateChange?.('opening');
-        },
-        notifyOpened: () => {
-          emit('onOpened', {});
-          getProps().onStateChange?.('opened');
-        },
-        notifyClosing: (action: string) => {
-          emit('onClose', action ? { action } : {});
-          getProps().onStateChange?.('closing');
-        },
-        notifyClosed: (action: string) => {
-          emit('onClosed', action ? { action } : {});
-          getProps().onStateChange?.('closed');
-        },
+        notifyOpening: () =>  emit('onOpen', {}),
+        notifyOpened: () =>  emit('onOpened', {}),
+        notifyClosing: (action: string) =>  
+          emit('onClose', action ? { action } : {}),
+        notifyClosed: (action: string) => 
+          emit('onClosed', action ? { action } : {}),
         getInitialFocusEl: () =>
           document.querySelector(
             `[${MDCDialogFoundation.strings.INITIAL_FOCUS_ATTRIBUTE}]`

--- a/src/dialog/readme.tsx
+++ b/src/dialog/readme.tsx
@@ -43,6 +43,7 @@ export default function() {
                   console.log(evt.detail.action);
                   setOpen(false);
                 }}
+                onClosed={evt => console.log(evt.detail.action)}
               >
                 <DialogTitle>Dialog Title</DialogTitle>
                 <DialogContent>This is a standard dialog.</DialogContent>


### PR DESCRIPTION
closes #569 

1. adds `DialogOnOpenedEventT`  and `DialogOnClosedEventT` and formally adds methods `onOpened` and `onClosed` 
2. updates documentation to include onOpened and onClosed 
    - At least I believe that to be the case. I edited readme.tsx only. If I understand properly it will be added automatically from there
3. modifies dialog.spec.tsx to also listen for `onOpened` and `onClosed`

Left outstanding, in my opinion, is the need for `onStateChanged`. Is it necessary. At the very least should it not also include the action in close and closed instances? I suppose it would be a breaking change, but if ever was the time to implement a braking change.... ;)