### PR TITLE
Feat/list/a11y updates

### DIFF
--- a/src/list/list-item.tsx
+++ b/src/list/list-item.tsx
@@ -72,7 +72,7 @@ export interface ListItemGraphicProps extends IconProps {}
 export const ListItemGraphic = createComponent<ListItemGraphicProps>(
   function ListItemGraphic(props, ref) {
     const className = useClassNames(props, ['mdc-list-item__graphic']);
-    return <Icon {...props} ref={ref} className={className} />;
+    return <Icon {...props} aria-hidden="true" ref={ref} className={className} />;
   }
 );
 
@@ -85,7 +85,7 @@ export const ListItemMeta = createComponent<ListItemMetaProps>(
     const className = useClassNames(props, ['mdc-list-item__meta']);
 
     if (!!props.icon) {
-      return <Icon {...props} ref={ref} className={className} />;
+      return <Icon {...props} aria-hidden="true" ref={ref} className={className} />;
     }
 
     if (React.isValidElement(props.children)) {

--- a/src/list/list-item.tsx
+++ b/src/list/list-item.tsx
@@ -13,6 +13,7 @@ export interface ListItemProps extends RMWC.WithRippleProps {
   activated?: boolean;
   /** A modifier for a disabled state. */
   disabled?: boolean;
+
 }
 
 /** A ListItem component. */
@@ -27,7 +28,7 @@ export const ListItem = withRipple({ surface: false })(
         'mdc-list-item--disabled': props.disabled
       }
     ]);
-    return <Tag tabIndex={0} {...rest} className={className} ref={ref} />;
+    return <Tag tag="li" tabIndex={0} {...rest} className={className} ref={ref} />;
   })
 );
 
@@ -130,7 +131,7 @@ export interface ListDividerProps {}
 export const ListDivider = createComponent<ListDividerProps>(
   function ListDivider(props, ref) {
     const className = useClassNames(props, ['mdc-list-divider']);
-    return <Tag {...props} ref={ref} className={className} />;
+    return <Tag tag="li" role="separator" {...props} ref={ref} className={className} />;
   }
 );
 

--- a/src/list/list.tsx
+++ b/src/list/list.tsx
@@ -60,5 +60,5 @@ export const List = createComponent<ListProps>(function List(props, ref) {
       'mdc-list--non-interactive': nonInteractive
     }
   ]);
-  return <Tag {...rest} element={rootEl} className={className} ref={ref} />;
+  return <Tag tag="ul" {...rest} element={rootEl} className={className} ref={ref} />;
 });


### PR DESCRIPTION

1. Lists now render as `<ul>`  closes #573
2. ListItem's now render as `<li>` closes #573
3. ListItemDivders now render `<li>` closes #573
4. ListItemDividers now render with attribute `role="separator"` - closes #574
5. ListItemGraphic and ListItemMeta (when an Icon) now render with attribute `aria-hidden="true"` closes #575