### PR TITLE
fix(top-app-bar): Fix wrong className for TopAppBarAdjust

### DIFF
--- a/src/top-app-bar/index.tsx
+++ b/src/top-app-bar/index.tsx
@@ -228,8 +228,8 @@ export const TopAppBarFixedAdjust = createComponent<TopAppBarFixedAdjustProps>(
   function TopAppBarFixedAdjust(props, ref) {
     const { dense, denseProminent, prominent, short, ...rest } = props;
     const className = useClassNames(props, [
-      'mdc-top-app-bar--fixed-adjust',
       {
+        'mdc-top-app-bar--fixed-adjust': !props.dense && !props.denseProminent && !props.prominent && !props.short,
         'mdc-top-app-bar--dense-fixed-adjust': props.dense,
         'mdc-top-app-bar--prominent-fixed-adjust': props.prominent,
         'mdc-top-app-bar--dense-prominent-fixed-adjust': props.denseProminent,


### PR DESCRIPTION
Hi,
I want to resolve this issue, #634. 
Since media query, className `mdc-top-app-bar--fixed-adjust` has higher priority than `.mdc-top-app-bar--dense-fixed-adjust` in `<TopAppBarFixedAdjust dense />`.

So, I want to add className `mdc-top-app-bar--fixed-adjust` when all props (dense, denseProminent, prominent, short) are undefined or false. 
Since the only css property that `mdc-top-app-bar--fixed-adjust` or `.mdc-top-app-bar--dense-fixed-adjust` manipulates is `padding-top`, I think this PR makes sense.
But, I know this PR makes the className `mdc-top-app-bar--fixed-adjust` loose its role as default className for `<TopAppBarFixedAdjust />`
In addition, I'm worried since this line need update if another property of `TopAppBarFixedAdjust` is created newly.

If you have more appropriate idea, please let me know.

Thanks!!

<img width="492" alt="image" src="https://user-images.githubusercontent.com/34697855/82202718-4fda9000-993d-11ea-8077-da934d1119ba.png">

 (In `<TopAppBarFixedAdjust dense />`, I want 48px padding-top but 56px is activated)

resolve: #634 
