### PR TITLE
fix(TopAppBar): Wrong className for TopAppBarFixedAdjust

### DIFF
--- a/src/top-app-bar/index.tsx
+++ b/src/top-app-bar/index.tsx
@@ -227,15 +227,24 @@ export interface TopAppBarFixedAdjustProps {
 export const TopAppBarFixedAdjust = createComponent<TopAppBarFixedAdjustProps>(
   function TopAppBarFixedAdjust(props, ref) {
     const { dense, denseProminent, prominent, short, ...rest } = props;
-    const className = useClassNames(props, [
-      'mdc-top-app-bar--fixed-adjust',
-      {
-        'mdc-top-app-bar--dense-fixed-adjust': props.dense,
-        'mdc-top-app-bar--prominent-fixed-adjust': props.prominent,
-        'mdc-top-app-bar--dense-prominent-fixed-adjust': props.denseProminent,
-        'mdc-top-app-bar--short-fixed-adjust': props.short
-      }
-    ]);
+    const classNames: string[] = [];
+    if (dense) {
+      classNames.push('mdc-top-app-bar--dense-fixed-adjust')
+    }
+    if (denseProminent) {
+      classNames.push('mdc-top-app-bar--dense-prominent-fixed-adjust')
+    }
+    if (prominent) {
+      classNames.push('mdc-top-app-bar--prominent-fixed-adjust')
+    }
+    if (short) {
+      classNames.push('mdc-top-app-bar--short-fixed-adjust')
+    }
+    // Use the default class
+    if (classNames.length === 0) {
+      classNames.push('mdc-top-app-bar--fixed-adjust')
+    }
+    const className = useClassNames(props, classNames);
     return <Tag {...rest} ref={ref} className={className} />;
   }
 );

--- a/src/top-app-bar/top-app-bar.spec.tsx
+++ b/src/top-app-bar/top-app-bar.spec.tsx
@@ -112,22 +112,37 @@ describe('TopAppBar', () => {
 
 describe('TopAppBarFixedAdjust', () => {
   it('renders', () => {
-    mount(<TopAppBarFixedAdjust />);
+    const el = mount(<TopAppBarFixedAdjust />);
+    const div = el.find('div');
+    const classNames = new Set((div.props().className ?? "").split(" "));
+    expect(classNames).toEqual(new Set(['mdc-top-app-bar--fixed-adjust']));
   });
 
   it('can be short', () => {
-    mount(<TopAppBarFixedAdjust short />);
+    const el = mount(<TopAppBarFixedAdjust short />);
+    const div = el.find('div');
+    const classNames = new Set((div.props().className ?? "").split(" "));
+    expect(classNames).toEqual(new Set(['mdc-top-app-bar--short-fixed-adjust']));
   });
 
   it('can be dense', () => {
-    mount(<TopAppBarFixedAdjust dense />);
+    const el = mount(<TopAppBarFixedAdjust dense />);
+    const div = el.find('div');
+    const classNames = new Set((div.props().className ?? "").split(" "));
+    expect(classNames).toEqual(new Set(['mdc-top-app-bar--dense-fixed-adjust']));
   });
 
   it('can be prominent', () => {
-    mount(<TopAppBarFixedAdjust prominent />);
+    const el = mount(<TopAppBarFixedAdjust prominent />);
+    const div = el.find('div');
+    const classNames = new Set((div.props().className ?? "").split(" "));
+    expect(classNames).toEqual(new Set(['mdc-top-app-bar--prominent-fixed-adjust']));
   });
 
   it('can be denseProminent', () => {
-    mount(<TopAppBarFixedAdjust denseProminent />);
+    const el = mount(<TopAppBarFixedAdjust denseProminent />);
+    const div = el.find('div');
+    const classNames = new Set((div.props().className ?? "").split(" "));
+    expect(classNames).toEqual(new Set(['mdc-top-app-bar--dense-prominent-fixed-adjust']));
   });
 });


### PR DESCRIPTION
It fixes #634 

This PR adds some tests for checking class names in `TopAppBarFixedAdjust` components and updates code to pass the tests