### PR TITLE
fix(Select): fixed menu props not forwarding for enhanced select

### DIFF
--- a/src/select/select/index.tsx
+++ b/src/select/select/index.tsx
@@ -336,6 +336,8 @@ export const Select: RMWC.ComponentType<
     }
   ]);
 
+  const enhancedMenuProps = typeof enhanced === 'object' ? enhanced : {};
+
   const defaultValue =
     value !== undefined ? undefined : props.defaultValue || '';
 
@@ -417,6 +419,7 @@ export const Select: RMWC.ComponentType<
         {enhanced && (
           <EnhancedMenu
             {...rest}
+            {...enhancedMenuProps}
             anchorCorner="bottomStart"
             defaultValue={defaultValue}
             placeholder={placeholder}


### PR DESCRIPTION
This bug did not allow MenuProps like "renderToPortal" to be forwarded to menu for enhanced select when passing in an object in "enhanced" prop.