### PR TITLE
fix(Select): spread enhanced prop to EnhancedMenu

### DIFF
--- a/src/select/select/index.tsx
+++ b/src/select/select/index.tsx
@@ -416,7 +416,7 @@ export const Select: RMWC.ComponentType<
 
         {enhanced && (
           <EnhancedMenu
-            {...rest}
+            {...enhanced}
             anchorCorner="bottomStart"
             defaultValue={defaultValue}
             placeholder={placeholder}


### PR DESCRIPTION
Fixes #613 by spreading the `enhanced` prop to the `EnhancedMenu` (which in turn spreads it to the `Menu`). 

This is consistent with what is specified in [the documentation](https://rmwc.io/select-menus):
> `enhanced` | `boolean` \| `MenuProps` | Renders a non native / enhanced dropdown

And it's consistent with what @jamesmfriedman was saying earlier:
> Not sure about your question at the end there @nicholaschiang. The props signature of an enhanced select (the kind that would need "renderToPortal" is either a boolean OR menu props.
> ```tsx
> <Select enhanced={{renderToPortal: true}} />
> ```

Note that I'm not 100% sure that this fixes all the issues brought up in #613 or #627 but it at least makes the implementation consistent with the documentation.