### PR TITLE
Fix typings for rmwc package

### DIFF
--- a/src/rmwc/package.json
+++ b/src/rmwc/package.json
@@ -3,7 +3,7 @@
   "version": "6.1.3",
   "description": "RMWC is a React UI Kit built on Google's official Material Components Web library.",
   "main": "dist/index.js",
-  "types": "index.d.ts",
+  "types": "dist/index.d.ts",
   "module": "next/index.js",
   "sideEffects": true,
   "publishConfig": {


### PR DESCRIPTION
Right now the typings for e.g. `import { Button } from 'rmwc'` are not imported correctly.