### PR TITLE
Fix clicking items in Menus and enhanced Select menus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "rmwc-main",
-	"version": "6.0.0",
+	"version": "6.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -12693,12 +12693,6 @@
 			"integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
 			"dev": true
 		},
-		"find-project-root": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/find-project-root/-/find-project-root-1.1.1.tgz",
-			"integrity": "sha1-0kJyei2QRyXfVxTyPf3N7doLbvg=",
-			"dev": true
-		},
 		"find-root": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
@@ -19304,7 +19298,8 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -20680,64 +20675,62 @@
 			"from": "github:prettier/prettier#master",
 			"dev": true,
 			"requires": {
-				"@angular/compiler": "9.0.5",
-				"@babel/code-frame": "7.8.0",
-				"@babel/parser": "7.9.4",
-				"@glimmer/syntax": "0.48.0",
-				"@iarna/toml": "2.2.3",
-				"@typescript-eslint/typescript-estree": "2.25.0",
-				"angular-estree-parser": "1.3.0",
-				"angular-html-parser": "1.4.0",
-				"camelcase": "5.3.1",
-				"chalk": "3.0.0",
+				"@angular/compiler": "10.0.3",
+				"@babel/code-frame": "7.10.4",
+				"@babel/parser": "7.10.5",
+				"@glimmer/syntax": "0.54.1",
+				"@iarna/toml": "2.2.5",
+				"@typescript-eslint/typescript-estree": "3.6.1",
+				"angular-estree-parser": "2.1.0",
+				"angular-html-parser": "1.7.1",
+				"camelcase": "6.0.0",
+				"chalk": "4.1.0",
 				"ci-info": "github:watson/ci-info#f43f6a1cefff47fb361c88cf4b943fdbcaafe540",
 				"cjk-regex": "2.0.0",
 				"cosmiconfig": "6.0.0",
 				"dashify": "2.0.0",
-				"dedent": "0.7.0",
 				"diff": "4.0.2",
 				"editorconfig": "0.15.3",
 				"editorconfig-to-prettier": "0.1.1",
-				"escape-string-regexp": "2.0.0",
+				"escape-string-regexp": "4.0.0",
 				"esutils": "2.0.3",
-				"fast-glob": "3.2.2",
+				"fast-glob": "3.2.4",
+				"fast-json-stable-stringify": "2.1.0",
 				"find-parent-dir": "0.3.0",
-				"find-project-root": "1.1.1",
-				"flow-parser": "0.121.0",
+				"flow-parser": "0.129.0",
 				"get-stream": "5.1.0",
-				"globby": "11.0.0",
-				"graphql": "14.6.0",
+				"globby": "11.0.1",
+				"graphql": "15.3.0",
 				"html-element-attributes": "2.2.1",
 				"html-styles": "1.0.0",
 				"html-tag-names": "1.1.5",
 				"ignore": "4.0.6",
-				"jest-docblock": "25.2.3",
-				"json-stable-stringify": "1.0.1",
+				"jest-docblock": "26.0.0",
 				"leven": "3.1.0",
 				"lines-and-columns": "1.1.6",
-				"linguist-languages": "7.9.0",
-				"lodash": "4.17.15",
-				"mem": "6.0.1",
+				"linguist-languages": "7.10.0",
+				"lodash": "4.17.19",
+				"mem": "6.1.0",
 				"minimatch": "3.0.4",
 				"minimist": "1.2.5",
 				"n-readlines": "1.0.0",
 				"please-upgrade-node": "3.2.0",
 				"postcss-less": "3.1.4",
 				"postcss-media-query-parser": "0.2.3",
-				"postcss-scss": "2.0.0",
+				"postcss-scss": "2.1.1",
 				"postcss-selector-parser": "2.2.3",
 				"postcss-values-parser": "2.0.1",
 				"regexp-util": "1.2.2",
 				"remark-math": "1.0.6",
-				"remark-parse": "5.0.0",
-				"semver": "7.1.3",
-				"srcset": "2.0.1",
+				"remark-parse": "8.0.2",
+				"resolve": "1.17.0",
+				"semver": "7.3.2",
 				"string-width": "4.2.0",
-				"typescript": "3.8.3",
+				"typescript": "3.9.6",
 				"unicode-regex": "3.0.0",
-				"unified": "8.4.2",
+				"unified": "9.0.0",
 				"vnopts": "1.0.2",
-				"yaml-unist-parser": "1.1.1"
+				"yaml-unist-parser": "1.2.1"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -21047,6 +21040,7 @@
 					"version": "1.17.0",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
 					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+					"dev": true,
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
@@ -25882,12 +25876,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
-		},
-		"srcset": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/srcset/-/srcset-2.0.1.tgz",
-			"integrity": "sha512-00kZI87TdRKwt+P8jj8UZxbfp7mK2ufxcIMWvhAOZNJTRROimpHeruWrGvCZneiuVDLqdyHefVp748ECTnyUBQ==",
 			"dev": true
 		},
 		"sshpk": {

--- a/src/base/foundation-component.tsx
+++ b/src/base/foundation-component.tsx
@@ -290,6 +290,7 @@ export const useFoundation = <
   useEffect(() => {
     const f = foundation;
     f.init();
+    api && handleRef(props.current.apiRef, api({ foundation, ...elements }));
     handleRef(props.current.foundationRef, f);
 
     return () => {

--- a/src/base/foundation-component.tsx
+++ b/src/base/foundation-component.tsx
@@ -290,7 +290,7 @@ export const useFoundation = <
   useEffect(() => {
     const f = foundation;
     f.init();
-    api && handleRef(props.current.apiRef, api({ f, ...elements }));
+    api && handleRef(props.current.apiRef, api({ foundation: f, ...elements }));
     handleRef(props.current.foundationRef, f);
 
     return () => {

--- a/src/base/foundation-component.tsx
+++ b/src/base/foundation-component.tsx
@@ -290,7 +290,7 @@ export const useFoundation = <
   useEffect(() => {
     const f = foundation;
     f.init();
-    api && handleRef(props.current.apiRef, api({ foundation, ...elements }));
+    api && handleRef(props.current.apiRef, api({ f, ...elements }));
     handleRef(props.current.foundationRef, f);
 
     return () => {

--- a/src/menu/menu.story.tsx
+++ b/src/menu/menu.story.tsx
@@ -104,6 +104,7 @@ class MenuSurfaceStory extends React.Component {
 }
 
 function MenuHoist() {
+  const [selected, setSelected] = useKnob('number', 'Last selected index', -1);
   const [hoisted] = useKnob('boolean', 'hoisted', true);
   const [open, setOpen] = React.useState(true);
   const [options] = useKnob('array', 'options', [
@@ -111,6 +112,7 @@ function MenuHoist() {
     'Pizza',
     'Icecream'
   ]);
+
   return (
     <div style={{ margin: '200px', height: '56px', overflow: 'hidden' }}>
       <MenuSurfaceAnchor>
@@ -125,10 +127,16 @@ function MenuHoist() {
         <Menu
           open={open}
           renderToPortal={hoisted}
+          onSelect={evt => setSelected(evt.detail.index)}
           onClose={() => setOpen(false)}
         >
-          {options.map((o: string) => (
-            <MenuItem key={o}>{o}</MenuItem>
+          {options.map((o: string, index: number) => (
+            <MenuItem
+              key={o}
+              activated={selected === index}
+            >
+              {o}
+            </MenuItem>
           ))}
         </Menu>
       </MenuSurfaceAnchor>

--- a/src/select/select.story.tsx
+++ b/src/select/select.story.tsx
@@ -6,6 +6,7 @@ import { text, object, array } from '@storybook/addon-knobs';
 import { Select } from './';
 import { useKnob } from '@rmwc/base/utils/use-knob';
 import { MenuItems, MenuItem } from '@rmwc/menu';
+import { Portal } from '@rmwc/base';
 
 function MutatingSelect(props: any) {
   const [value, setValue] = useKnob('text', 'value', 'Cookies');
@@ -233,6 +234,34 @@ function ControlledSelect() {
   );
 }
 
+
+function EnhancedSelectWithPortal(props: any) {
+  const [value, setValue] = useKnob('text', 'value', "Cookies");
+
+  return (
+    <>
+      <Portal/>
+      <Select
+        label={'Enhanced with Portal'}
+        enhanced={{
+          renderToPortal: true
+        }}
+        value={value}
+        onChange={(evt) => {
+          const value = evt.currentTarget.value;
+          console.log('onChange', value);
+          setValue(value === undefined ? "undefined" : value);
+        }}
+        options={[
+          'Cookies',
+          'Pizza',
+          'Icecream'
+        ]}
+      />
+    </>
+  );
+}
+
 storiesOf('Select', module)
   .add('Select with object', () => (
     <Select
@@ -269,6 +298,7 @@ storiesOf('Select', module)
       </Select>
     </div>
   ))
+  .add('Select Enhanced with Portal', () => <EnhancedSelectWithPortal/>)
   .add('Select without placeholder', () => (
     <Select
       label={text('label', 'Foods')}


### PR DESCRIPTION
Currently Menus and enhanced Select menus using renderToPortal to render the pop-up containing the menu items to a Portal are broken. Clicking menu items does nothing and the onSelect callback is never called.

This seemingly happens because the useFoundation() hook from @rmwc/base seems to set null as the apiRef/listApi reference in the Menu foundation when the cleanup function of the useEffect() hook in useFoundation() is called. The same useEffect() hook then never re-sets the listApi leaving it as null. This seems to only happen when renderToPortal is used for some reason. 

As a solution the useEffect() hook now sets the apiRef of components every time it is run in addition to the apiRef being set in the useMemo() hook. This seems to fix the behaviours of both type of menus. Does this seem sensible?

I also modified the Menu story that uses renderToPortal to show the active index and added a new Select story that uses a Portal. These helped me in debugging.

This PR should fix the problems described by me and some others in https://github.com/jamesmfriedman/rmwc/issues/613.