### PR TITLE
feat(Tab): Add ability to set focusOnActivate

### DIFF
--- a/src/tabs/tab-foundation.tsx
+++ b/src/tabs/tab-foundation.tsx
@@ -77,6 +77,11 @@ export const useTabFoundation = (props: TabProps & React.HTMLProps<any>) => {
     };
   }, [contextApi, tabApi]);
 
+  useEffect(() => {
+    props.focusOnActivate !== undefined &&
+      foundation.setFocusOnActivate(props.focusOnActivate);
+  }, [foundation, props.focusOnActivate]);
+
   return {
     ...elements,
     setTabIndicatorApi

--- a/src/tabs/tab.tsx
+++ b/src/tabs/tab.tsx
@@ -38,6 +38,8 @@ export interface TabProps {
   onInteraction?: (evt: TabOnInteractionEventT) => void;
   /** Advanced: A reference to the MDCFoundation. */
   foundationRef?: React.Ref<MDCTabFoundation | null>;
+  /** Focuses the tab when activated. Defaults to true. */
+  focusOnActivate?: boolean;
 }
 
 export type TabApi = {
@@ -86,6 +88,7 @@ export const Tab = createComponent<TabProps>(function Tab(props, ref) {
     onInteraction,
     iconIndicator,
     foundationRef,
+    focusOnActivate,
     ...rest
   } = props;
 

--- a/src/tabs/tabs.spec.tsx
+++ b/src/tabs/tabs.spec.tsx
@@ -103,6 +103,8 @@ describe('Tabs', () => {
     window.requestAnimationFrame(() => {
       expect(el1.html().includes('mdc-tab--active')).toEqual(true);
       expect(el2.html().includes('mdc-tab--active')).toEqual(true);
+      el1.unmount();
+      el2.unmount();
       done();
     });
   });
@@ -117,10 +119,33 @@ describe('Tabs', () => {
 
     el.find(Tab).first().simulate('click');
     
-    // expect(el.find(Tab).last().hasClass('mdc-tab--active')).toEqual(true);
     window.requestAnimationFrame(() => {
-      // expect(el.find(Tab).last().html()).toEqual(""); // ('mdc-tab--active')).toEqual(true);
       expect(el.find(Tab).last().html().includes('mdc-tab--active')).toEqual(true);
+      el.unmount();
+      done();
+    });
+  });
+  
+  it('focuses active tab on mount', (done) => {
+    const el = mount(<TabBar>
+        <Tab focusOnActivate>Test</Tab>
+      </TabBar>);
+    
+    window.requestAnimationFrame(() => {
+      expect(document.activeElement).toBe(el.find('button').getDOMNode());
+      el.unmount();
+      done();
+    });
+  });
+  
+  it('does not focus active tab on mount', (done) => {
+    const el = mount(<TabBar>
+      <Tab focusOnActivate={false}>Test</Tab>
+    </TabBar>);
+  
+    window.requestAnimationFrame(() => {
+      expect(document.activeElement).not.toBe(el.find('button').getDOMNode());
+      el.unmount();
       done();
     });
   });


### PR DESCRIPTION
This PR allows the tabs to be configured as to whether they should automatically focus when activated. This is set to true by default in MDC Web, but can be configured through the foundation.

When true, the active tab will immediately gain focus on page load. In this case it's the "Pizza" tab in "Always 1"
<img width="1308" alt="chrome_2020-07-27_15-24-28" src="https://user-images.githubusercontent.com/3473227/88548121-f1a5e980-d01e-11ea-8793-87f1b4a65996.png">

If we set the Tabs in the "Always 1" example to have `focusOnActivate={false}, then the focus will not be set on this set of tabs and focus will remain on the previous story that still has the default behavior.
<img width="1244" alt="chrome_2020-07-27_15-26-00" src="https://user-images.githubusercontent.com/3473227/88548284-33cf2b00-d01f-11ea-9952-5f8a468a9615.png">


Resolves: #557 