### PR TITLE
Do not pass "wrapFocus" List prop to Tag

### DIFF
--- a/src/list/list.tsx
+++ b/src/list/list.tsx
@@ -54,9 +54,13 @@ export const List = createComponent<ListProps>(function List(props, ref) {
     nonInteractive,
     onAction,
     foundationRef,
+    wrapFocus,
     ...rest
   } = props;
-  const { rootEl } = useListFoundation(props);
+  const { rootEl } = useListFoundation({
+    ...props,
+    wrapFocus
+  });
   const className = useClassNames(props, [
     'mdc-list',
     {


### PR DESCRIPTION
Allowing `wrapFocus` to remain in the `...rest` parameter will throw a react-dom warning about an unrecognized prop.