### PR TITLE
chore(Icon): Improve typings of icon render method

### DIFF
--- a/src/icon/icon.spec.tsx
+++ b/src/icon/icon.spec.tsx
@@ -128,4 +128,17 @@ describe('Icon', () => {
       `<div>Customized-CUSTOM</div>`
     );
   });
+
+  it('does not crash when custom render returns a string', () => {
+    const el = mount(
+      <Icon
+        icon={{
+          icon: 'CUSTOM',
+          strategy: 'custom',
+          render: () => 'custom',
+        }}
+      />
+    );
+    expect(el.html()).toBe(null);
+  });
 });

--- a/src/icon/index.tsx
+++ b/src/icon/index.tsx
@@ -86,7 +86,7 @@ const renderComponent = ({
 };
 
 const iconRenderMap: {
-  [key: string]: ((content: any, ...rest: any) => React.ReactNode) | undefined;
+  [key: string]: ((content: any, ...rest: any) => Exclude<React.ReactNode, "ReactText">) | undefined;
 } = {
   ligature: renderLigature,
   className: renderClassName,
@@ -155,11 +155,11 @@ export const Icon = createComponent<IconProps, IconHTMLProps>(function (
 
   const rendererFromMap = !!strategyToUse && iconRenderMap[strategyToUse];
 
-  // For some reason TS thinks the render method will return undefined...
-  const renderToUse: any =
-    strategyToUse === 'custom'
-      ? render || providerRender
-      : rendererFromMap || null;
+  let renderToUse = rendererFromMap || null;
+
+  if (strategyToUse === 'custom') {
+    renderToUse = render || providerRender;
+  }
 
   if (!renderToUse) {
     console.error(
@@ -185,6 +185,10 @@ export const Icon = createComponent<IconProps, IconHTMLProps>(function (
       }
     )
   });
+
+  if (!React.isValidElement<any>(rendered)) {
+    return null;
+  }
 
   const childDisplayName = getDisplayName(rendered.props.children);
 

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -91,7 +91,8 @@ export interface IconOptions {
   render?: (props: {
     content: IconElementT;
     className: string;
-  }) => React.ReactNode;
+    ref?: React.Ref<any>;
+  }) => Exclude<React.ReactNode, React.ReactText>; // Don't allow string | number, those would be rendered as {null} anyway
   /** A size to render the icon  */
   size?: IconSizeT;
   /** Additional props */


### PR DESCRIPTION
A small PR to start my contribution for RMWC.

Minor change is that the custom render method of Icon component may no longer return a string or a number (`ReactText` type is now excluded from the `ReactNode` union type). However, that should not change compatiblity since the code would have crashed anyway if users would return a `string | number` from the custom render method. 

Now it will simply return null when the render method doesn't return a valid `ReactElement`.