### PR TITLE
fix(snackbar): support SVGs as dismiss icon

### DIFF
--- a/src/snackbar/snackbar.tsx
+++ b/src/snackbar/snackbar.tsx
@@ -37,7 +37,7 @@ export interface SnackbarProps {
   /* Aligns the Snackbar to the start of the screen. */
   leading?: boolean;
   /* Shows a dismiss icon, */
-  dismissIcon?: boolean | string;
+  dismissIcon?: boolean | RMWC.IconPropT;
   /** Whether or not your want clicking an action to close the Snackbar. */
   dismissesOnAction?: boolean;
   /** An icon for the snackbar */


### PR DESCRIPTION
Allows users to specify their own SVGs or images to use as the `Snackbar` dismiss icon. Mirrors the existing behavior of the `Icon` and `IconButton` components.