### PR TITLE
Some tiny fixes

### DIFF
--- a/packages/base/src/lib/foundation-component.tsx
+++ b/packages/base/src/lib/foundation-component.tsx
@@ -17,8 +17,7 @@ export class FoundationElement<Props extends {}, ElementType = HTMLElement> {
   private _props: Partial<Props> = {};
   _onChange: (() => void) | null = null;
 
-  constructor(onChange: () => void) {
-    this._onChange = onChange;
+  constructor() {
     this.onChange = this.onChange.bind(this);
     this.addClass = this.addClass.bind(this);
     this.removeClass = this.removeClass.bind(this);
@@ -33,6 +32,10 @@ export class FoundationElement<Props extends {}, ElementType = HTMLElement> {
 
   onChange() {
     this._onChange && this._onChange();
+  }
+
+  init(onChange: () => void) {
+    this.onChange = onChange;
   }
 
   destroy() {
@@ -247,9 +250,7 @@ export const useFoundation = <
       Object.keys(elementsInput).reduce<{
         [key in keyof Elements]: FoundationElement<any, HTMLElement>;
       }>((acc, key: keyof Elements) => {
-        acc[key] = new FoundationElement<Props, HTMLElement>(() => {
-          refresh();
-        });
+        acc[key] = new FoundationElement<Props, HTMLElement>();
         return acc;
       }, {} as any),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -272,6 +273,8 @@ export const useFoundation = <
   }, []);
 
   useEffect(() => {
+    props.current = inputProps;
+    Object.values(elements).map((element) => element.init(refresh));
     const f = foundation;
     f.init();
     api && handleRef(props.current.apiRef, api({ foundation: f, ...elements }));

--- a/packages/list/src/lib/list-item.tsx
+++ b/packages/list/src/lib/list-item.tsx
@@ -242,7 +242,6 @@ export const SimpleListItem = createComponent<SimpleListItemProps>(
 
     return (
       <ListItem {...rest} ref={ref}>
-        <RippleSurface className="mdc-deprecated-list-item__ripple" />
         {graphic !== undefined && <ListItemGraphic icon={graphic} />}
         {secondaryTextToRender !== null ? (
           <ListItemText>

--- a/packages/ripple/src/lib/ripple.tsx
+++ b/packages/ripple/src/lib/ripple.tsx
@@ -1,7 +1,7 @@
 import * as RMWC from '@rmwc/types';
 import React from 'react';
 import { MDCRippleFoundation } from '@material/ripple';
-import { classNames } from '@rmwc/base';
+import { classNames, mergeRefs } from '@rmwc/base';
 import { useProviderContext } from '@rmwc/provider';
 import { useRippleFoundation } from './foundation';
 
@@ -96,7 +96,7 @@ export function Ripple(props: RippleProps & RMWC.HTMLProps) {
 
   // do some crazy props merging...
   const content = React.cloneElement(child, {
-    ref: rootEl.reactRef,
+    ref: mergeRefs(rootEl.reactRef, (child as any).ref),
     ...child.props,
     ...unboundedProp,
     ...rootEl.props({

--- a/packages/tabs/src/lib/tab-indicator-foundation.tsx
+++ b/packages/tabs/src/lib/tab-indicator-foundation.tsx
@@ -14,17 +14,17 @@ export const useTabIndicatorFoundation = (props: TabIndicatorProps) => {
     foundation: ({ rootEl, contentEl }) => {
       const adapter: MDCTabIndicatorAdapter = {
         addClass: (className: string) => {
-          rootEl.addClass(className);
+          rootEl.ref?.classList.add(className);
         },
         removeClass: (className: string) => {
-          rootEl.removeClass(className);
+          rootEl.ref?.classList.remove(className);
         },
         computeContentClientRect: () =>
           contentEl.ref
             ? contentEl.ref.getBoundingClientRect()
             : emptyClientRect,
         setContentStyleProperty: (prop: string, value: string) => {
-          contentEl.setStyle(prop, value);
+          contentEl.ref?.style.setProperty(prop, value);
         }
       };
 


### PR DESCRIPTION
For various reasons and coincidences, there is a PR in 2026. 😆
If this kind of things are no longer needed nowadays, feel free to ignore this PR, I'm not waiting for a new release to fix something.

## [fix(ripple): outer ref lost with withRipple](https://github.com/rmwc/rmwc/commit/4b7029a7396fc8ab35558b15f84b3b5ef416da03)
outer `ref` forwarded here:
https://github.com/rmwc/rmwc/blob/3592c8e2d452a2b0ffbfa2bb1009746f036e3aba/packages/ripple/src/lib/ripple.tsx#L152-L153
and passed here:
https://github.com/rmwc/rmwc/blob/3592c8e2d452a2b0ffbfa2bb1009746f036e3aba/packages/ripple/src/lib/ripple.tsx#L165-L167
but never used when clone `child`:
https://github.com/rmwc/rmwc/blob/3592c8e2d452a2b0ffbfa2bb1009746f036e3aba/packages/ripple/src/lib/ripple.tsx#L98-L108

## [fix(base): useEffect cleanup should not irreversible](https://github.com/rmwc/rmwc/commit/b125a44e255445ac9dbe1cc4a67e8791f7599b29)
this could fix the core issue related to `<Activity>` and `<StrictMode>`.

## [fix(list): SimpleListItem includes RippleSurface twice](https://github.com/rmwc/rmwc/commit/8df53dbb727d481335bb02895625381807718544)
`SimpleListItem` uses `ListItem` and adds `RippleSurface`:
https://github.com/rmwc/rmwc/blob/3592c8e2d452a2b0ffbfa2bb1009746f036e3aba/packages/list/src/lib/list-item.tsx#L244-L245
`ListItem` adds `RippleSurface` too:
https://github.com/rmwc/rmwc/blob/3592c8e2d452a2b0ffbfa2bb1009746f036e3aba/packages/list/src/lib/list-item.tsx#L76-L77

## [fix(tab): indicator transition not working](https://github.com/rmwc/rmwc/commit/d598bf8b455f3d741f3338759788949d07b5db3a)
MDC implements indicator transition by adding classes and styles, forcing repaint, then removing them instantly:
https://github.com/material-components/material-components-web/blob/6ceadb81df508ac08ab007c52c4d3dc1d811cc15/packages/mdc-tab-indicator/sliding-foundation.ts#L46-L57
it's too late to wait `useFoundation` inner `refresh`, dom manipulation should be safe here since changes are reverted immediately.